### PR TITLE
Add server time endpoint

### DIFF
--- a/src/main/resources/templates/time.html
+++ b/src/main/resources/templates/time.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8" />
+    <title>Server Time</title>
+</head>
+<body>
+<p>Server time (ns): <span id="serverTime" th:text="${serverTime}"></span></p>
+<p>Client time (ns): <span id="clientTime"></span></p>
+<p>Difference (ns): <span id="diff"></span></p>
+<script type="text/javascript">
+    var serverTime = Number(document.getElementById('serverTime').textContent);
+    var clientTime = Date.now() * 1000000;
+    document.getElementById('clientTime').textContent = clientTime;
+    document.getElementById('diff').textContent = clientTime - serverTime;
+</script>
+</body>
+</html>

--- a/src/main/scala/com/shams/ss/web/TimeController.scala
+++ b/src/main/scala/com/shams/ss/web/TimeController.scala
@@ -1,0 +1,16 @@
+package com.shams.ss.web
+
+import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.ui.Model
+
+@Controller
+class TimeController {
+
+  @RequestMapping(Array("/time"))
+  def time(model: Model): String = {
+    val serverTimeNs: Long = System.currentTimeMillis() * 1000000L
+    model.addAttribute("serverTime", serverTimeNs)
+    "time"
+  }
+}


### PR DESCRIPTION
## Summary
- add `TimeController` returning server time in nanoseconds
- render the value via a new Thymeleaf template that compares with client time

## Testing
- `gradle test` *(fails: Configuration with name 'runtime' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881be3c737c832586c08760a26d97a6